### PR TITLE
Add Support for Excluding Specific File Extensions via -X Argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ python all_code.py -c
 python all_code.py -d /path/to/start/directory -c
 ```
 
+**Exclude Specific File Extensions**
+```bash
+python all_code.py -X .json,.md,.html
+```
+**Combine Multiple Options: Specify Directory, Copy to Clipboard, and Exclude Extensions**
+```bash
+python all_code.py -d /path/to/start/directory -c -X .json,.md,.html
+```
+
 **More options**
 ```bash
 python all_code.py --help
@@ -55,6 +64,8 @@ options:
                         Comma-separated list of programming extensions to use. Replaces the default set if provided.
   -e, --exclude-dirs EXCLUDE_DIRS
                         Comma-separated list of directories to exclude. Replaces the default set if provided.
+  -X, --exclude-extensions EXCLUDE_EXTENSIONS
+                        Comma-separated list of file extensions to exclude from aggregation.
 ```
 
 ## Exclusions
@@ -74,6 +85,16 @@ The following directories are excluded by default:
 - `temp`
 - `old_files`
 - `flask_session`
+
+### Excluded Extensions
+
+Users can now exclude specific file extensions using the `-X` or `--exclude-extensions` argument.
+
+**Example:**
+```bash
+python all_code.py -X .json,.md,.html
+```
+This will exclude all .json, .md, and .html files from aggregation.
 
 **Purpose**: These directories are typically used for virtual environments, dependencies, build artifacts, version control, or temporary files that are not part of the core codebase.
 

--- a/all_code.py
+++ b/all_code.py
@@ -210,8 +210,7 @@ def main():
         sys.exit(1)
 
     if not os.path.isdir(startpath):
-        print(f"Error: The specified directory '{
-              startpath}' does not exist or is not a directory.")
+        print(f"Error: The specified directory '{startpath}' does not exist or is not a directory.")
         sys.exit(1)
 
     # Generate directory tree

--- a/all_code.py
+++ b/all_code.py
@@ -252,8 +252,7 @@ def main():
             if should_exclude(rel_file_path) or not should_include_file(file_path):
                 continue  # Skip excluded files or those not in FILES_TO_INCLUDE
 
-            header = f"\n\n# ======================\n# File: {
-                rel_file_path}\n# ======================\n\n"
+            header = f"\n\n# ======================\n# File: {rel_file_path}\n# ======================\n\n"
             aggregated_content += header
 
             try:
@@ -277,8 +276,7 @@ def main():
         try:
             with open(FULL_CODE_FILE_NAME, 'w', encoding='utf-8') as master_file:
                 master_file.write(aggregated_content)
-            print(f"Full code file '{
-                  FULL_CODE_FILE_NAME}' has been created successfully.")
+            print(f"Full code file '{FULL_CODE_FILE_NAME}' has been created successfully.")
         except Exception as e:
             print(f"Error writing to file '{FULL_CODE_FILE_NAME}': {e}")
             sys.exit(1)

--- a/all_code.py
+++ b/all_code.py
@@ -191,7 +191,7 @@ def main():
     args = parse_arguments()
 
     # Override the global options if command line arguments are provided.
-    global FULL_CODE_FILE_NAME, FILES_TO_INCLUDE, PROGRAMMING_EXTENSIONS, EXCLUDE_DIRS
+    global FULL_CODE_FILE_NAME, FILES_TO_INCLUDE, PROGRAMMING_EXTENSIONS, EXCLUDE_DIRS, EXCLUDE_EXTENSIONS
 
     if args.output_file:
         FULL_CODE_FILE_NAME = args.output_file


### PR DESCRIPTION
This PR adds support for excluding specific file extensions from aggregation using the -X or --exclude-extensions argument. Users can now specify extensions to ignore, ensuring that files like .json, .md, or .html are not included in full_code.txt. The feature enhances flexibility by allowing control over which files are aggregated.