### PR TITLE
Remove unused imports

### DIFF
--- a/all_code.py
+++ b/all_code.py
@@ -14,8 +14,6 @@
 import os
 import argparse
 import sys
-import tkinter as tk
-import tkinter.messagebox as messagebox
 import subprocess
 
 # Define the master file name


### PR DESCRIPTION
Like the title says, removes unused imports. My install of Python doesn't have tkinter and it is not used.