### PR TITLE
Add Windows clipboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,14 @@ The **All Code Aggregator** script consolidates all programming-related code fil
 - **Directory Tree Generation**: Creates an ASCII representation of the directory structure, excluding specified directories.
 - **Code Aggregation**: Combines contents of programming-related files into a master file.
 - **Customizable Inclusions/Exclusions**: Easily specify which files or directories to include or exclude.
+- **Clipboard Output**: Use `-c` to copy the results directly to your clipboard on macOS and Windows 10+.
 
 ## Setup
 
 1. **From Github**
 
 ```shell
-pip install git+https://github.com/foxalabs/all_code@0.3.0
+pip install git+https://github.com/foxalabs/all_code@0.4.0
 ```
 
 2. **From local directory**
@@ -38,7 +39,7 @@ all-code
 all-code -d /path/to/start/directory
 ```
 
-**Copy Aggregated Content to Clipboard Instead of Writing to File**
+**Copy Aggregated Content to Clipboard Instead of Writing to File** (macOS and Windows 10+)
 ```bash
 all-code -c
 ```

--- a/all_code.py
+++ b/all_code.py
@@ -176,12 +176,23 @@ def parse_arguments():
                     help="Comma-separated list of file extensions to exclude.")
     return parser.parse_args()
 
-# TODO: Works on Macos. Needs Windows and Linux support
+# TODO: Works on MacOS and Windows 10+. Linux support can be added later
 def copy_to_clipboard(content):
+    """Copy text to the system clipboard on macOS and Windows."""
     try:
-        process = subprocess.Popen('pbcopy', env={'LANG': 'en_US.UTF-8'}, stdin=subprocess.PIPE)
-        process.communicate(content.encode('utf-8'))
-        return True
+        if sys.platform == 'darwin':
+            process = subprocess.Popen('pbcopy', env={'LANG': 'en_US.UTF-8'}, stdin=subprocess.PIPE)
+            process.communicate(content.encode('utf-8'))
+            return process.returncode == 0
+        elif sys.platform.startswith('win'):
+            # Windows 10+ ships with the 'clip' utility
+            process = subprocess.Popen('clip', stdin=subprocess.PIPE, shell=True)
+            # clip expects UTF-16LE encoding
+            process.communicate(content.encode('utf-16le'))
+            return process.returncode == 0
+        else:
+            print("Clipboard copy is only supported on macOS and Windows 10+.")
+            return False
     except Exception as e:
         print(f"Error copying to clipboard: {e}")
         return False

--- a/full_code.txt
+++ b/full_code.txt
@@ -33,7 +33,7 @@ The **All Code Aggregator** script consolidates all programming-related code fil
 1. **From Github**
 
 ```shell
-pip install git+https://github.com/foxalabs/all_code@0.3.0
+pip install git+https://github.com/foxalabs/all_code@0.4.0
 ```
 
 2. **From local directory**
@@ -216,7 +216,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "all-code"
-version = "0.3.0"
+version = "0.4.0"
 description = "Aggregate code files into a single file with a directory tree."
 readme = "README.md"
 requires-python = ">=3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "all-code"
-version = "0.3.0"
+version = "0.4.0"
 description = "Aggregate code files into a single file with a directory tree."
 readme = "README.md"
 requires-python = ">=3.7"


### PR DESCRIPTION
## Summary
- add cross-platform clipboard support for Windows 10+
- document clipboard usage for macOS and Windows
- bump version to 0.4.0

## Testing
- `python test_all_code.py`

------
https://chatgpt.com/codex/tasks/task_e_686fc1f946f4832e86d2ef4de615dabb