### PR TITLE
Exclusions + tree clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,19 @@ venv.bak/
 
 # Swap files
 *.swp
+
+# Local files, scratch files
+out*.txt
+sandbox.txt
+sandbox_ext/
+tests/
+OGallcode.txt
+foo/
+verify_test.py
+out.txt
+sandbox/
+__pycache__
+.DS_Store
+*.pyc
+**/_currentcode*.txt
+/tests/out*.txt

--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ This fork focuses on **exclusion controls** and a few quality-of-life improvemen
 
 - **Output convenience**
   - `-o` accepts a subpath (create the folder first): `-o tests/out.txt`.
-  -
 - **New/clarified options**
 
-  - `-e, --exclude-dirs` — add names or paths to exclude (**additive**).
-  - `--replace-exclude-dirs` — replace the default excluded set entirely.
-  - `--exclude-files` — comma-separated globs or exact paths (absolute or project-relative).
+  - `-e, --exclude-dirs` — add names or **paths** to exclude (**additive**).
+  - `--replace-exclude-dirs` — **replace** the default excluded set entirely.
+  - `--exclude-files` — comma-separated **globs** or **exact paths** (absolute or project-relative).
   - `-X, --exclude-extensions` — extension denylist (wins over `-x`).
-  - `-x, --extensions` — extension allowlist (replaces the default “programming-like” set).
+  - `-x, --extensions` — extension allowlist (_replaces_ the default set “programming-like” set).
   - `--self` — include `all_code.py` in output (hidden by default to avoid self-inclusion).
 
 - **Tree < - > aggregation consistency**
@@ -31,71 +30,69 @@ This fork focuses on **exclusion controls** and a few quality-of-life improvemen
 **From GitHub (original project)**
 
 ```bash
-pip install git+https://github.com/foxalabs/all_code@0.4.0
-# from a local clone
-
 git clone https://github.com/foxalabs/all_code.git
 cd all_code
 pip install -e .
-
-
+```
 
 # Usage
 
-'''bash
+```bash
 all-code
-'''
+```
 
 ## Specify directory
 
-'''bash
+```bash
 all-code -d /path/to/project
-'''
+```
 
 ## Copy to clipboard (macOS / Windows 10+)
 
-'''bash
+```bash
 all-code -d /path/to/project -c
-'''
+```
 
 ## Write to a subfolder of directory
 
-'''bash
+```bash
 # mkdir -p tests
 all-code -d /path/to/project . -o tests/out.txt
+```
 
 ## Exclude by glob or exact path
 
-'''bash
+```bash
 all-code -d /path/to/project --exclude-files "foo/*.json,**/secrets.*"
-'''
+```
 
 ## Allowlist extensions (denylist wins if both set)
 
-'''bash
+```bash
 all-code -d /path/to/project -x ".py,.ts" -X ".py"
-'''
+```
 
 ## Add more excluded dirs (keeps defaults)
 
-'''bash
+```bash
 all-code -d /path/to/project -e "secret,bar"
-'''
+```
 
 ## Replace default excluded dirs entirely
 
-'''bash
+```bash
 all-code -d /path/to/project --replace-exclude-dirs -e "my_generated,build-cache"
-'''
+```
 
 ## Include the tool itself
 
-'''bash
+```bash
 all-code --self
-'''
+```
 
 # Output format
-'''php
+
+```php
 Directory Tree:
 project/
 │   ├── src/
@@ -107,30 +104,32 @@ project/
 # ======================
 
 print("hello world")
-'''
+```
 
 # Defaults & Notes
-Default excluded directories (not traversed): node_modules, .venv, venv, __pycache__, .git, dist, build, temp, old_files, flask_session.
 
-By default, only “programming-like” extensions are aggregated. Use -x to override or -X to deny specific extensions.
+- Default excluded directories (not traversed): node_modules, .venv, venv, **pycache**, .git, dist, build, temp, old_files, flask_session.
 
-Clipboard support is implemented for macOS (pbcopy) and Windows (clip).
+- By default, only “programming-like” extensions are aggregated. Use -x to override or -X to deny specific extensions.
+
+- Clipboard support is implemented for macOS (pbcopy) and Windows (clip).
 
 # Testing
-Run the following command
 
-'''bash
+- Run the following command
+
+```bash
 python test_all_code.py
-'''
+```
 
 # Changelog (this PR)
-Directory tree now marks user-excluded files with [EXCLUDED].
 
-Allow file address exlusion in addition to file name exclusion.
+- Directory tree now marks user-excluded files with [EXCLUDED].
 
-Add --exclude-files, --replace-exclude-dirs, --self.
+- Allow file address exlusion in addition to file name exclusion.
 
-Make -e additive by default (use --replace-exclude-dirs to replace).
+- Add --exclude-files, --replace-exclude-dirs, --self.
 
-Clarify precedence: -X (denylist) beats -x (allowlist).
-```
+- Make -e additive by default (use --replace-exclude-dirs to replace).
+
+- Clarity: -X (denylist) beats -x (allowlist).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ pip install git+https://github.com/foxalabs/all_code@0.4.0
 2. **From local directory**
 
 To install from a local directory, use edit mode so your code changes are reflected immediately. This is useful for development/debugging mode.
+
 ```shell
 git clone https://github.com/foxalabs/all_code.git
 cd all_code
@@ -29,36 +30,45 @@ pip install -e .
 ```
 
 ## Usage
+
 **Basic usage**
+
 ```bash
 all-code
 ```
 
 **Specify a Directory**
+
 ```bash
 all-code -d /path/to/start/directory
 ```
 
 **Copy Aggregated Content to Clipboard Instead of Writing to File** (macOS and Windows 10+)
+
 ```bash
 all-code -c
 ```
 
 **Combine Both Arguments: Specify Directory and Copy to Clipboard**
+
 ```bash
 all-code -d /path/to/start/directory -c
 ```
 
 **Exclude Specific File Extensions**
+
 ```bash
 all-code -X .json,.md,.html
 ```
+
 **Combine Multiple Options: Specify Directory, Copy to Clipboard, and Exclude Extensions**
+
 ```bash
 all-code -d /path/to/start/directory -c -X .json,.md,.html
 ```
 
 **More options**
+
 ```bash
 all-code --help
 usage: all_code.py [-h] [-c] [-d DIRECTORY] [-o OUTPUT_FILE] [-i INCLUDE_FILES] [-x EXTENSIONS] [-e EXCLUDE_DIRS]
@@ -77,7 +87,11 @@ options:
   -x, --extensions EXTENSIONS
                         Comma-separated list of programming extensions to use. Replaces the default set if provided.
   -e, --exclude-dirs EXCLUDE_DIRS
-                        Comma-separated list of directories to exclude. Replaces the default set if provided.
+                        Comma-separated directory names or paths to additionally exclude.
+      --replace-exclude-dirs
+                        Replace the default excluded directories entirely with those from -e.
+      --exclude-files EXCLUDE_FILES
+                        Comma-separated file paths or globs to exclude (abs or project-relative).
   -X, --exclude-extensions EXCLUDE_EXTENSIONS
                         Comma-separated list of file extensions to exclude from aggregation.
 ```
@@ -108,12 +122,17 @@ The following directories are excluded by default:
 Users can now exclude specific file extensions using the `-X` or `--exclude-extensions` argument.
 
 **Example:**
+
 ```bash
 all-code -X .json,.md,.html
+all-code --exclude-files "config/*.json,**/secrets.*"
+all-code --replace-exclude-dirs -e "my_generated,build-cache"
 ```
+
 This will exclude all .json, .md, and .html files from aggregation.
 
 ## Example Output to full_code.txt
+
 ```
 Directory Tree:
 all_code/
@@ -176,7 +195,6 @@ console.log("Subtract: " + subtract(5, 3)); // Output: Subtract: 2
 console.log("Multiply: " + multiply(5, 3)); // Output: Multiply: 15
 console.log("Divide: " + divide(5, 3));     // Output: Divide: 1.6666666666666667
 ```
-
 
 ## Testing the script
 

--- a/README.md
+++ b/README.md
@@ -1,207 +1,136 @@
 # All Code Aggregator
 
-## Overview
+Aggregate source files into a single text file that starts with a compact directory tree, followed by file-by-file sections. Great for sharing a self-contained snapshot with tools or reviewers.
 
-The **All Code Aggregator** script consolidates all programming-related code files in the current directory into a single `full_code.txt` file. This is especially useful for providing your entire codebase to AI models for analysis or assistance.
+---
 
-## Features
+## What’s in this PR (exclusions + clarity)
 
-- **Directory Tree Generation**: Creates an ASCII representation of the directory structure, excluding specified directories.
-- **Code Aggregation**: Combines contents of programming-related files into a master file.
-- **Customizable Inclusions/Exclusions**: Easily specify which files or directories to include or exclude.
-- **Clipboard Output**: Use `-c` to copy the results directly to your clipboard on macOS and Windows 10+.
+This fork focuses on **exclusion controls** and a few quality-of-life improvements:
 
-## Setup
+- **Output convenience**
+  - `-o` accepts a subpath (create the folder first): `-o tests/out.txt`.
+  -
+- **New/clarified options**
 
-1. **From Github**
+  - `-e, --exclude-dirs` — add names or paths to exclude (**additive**).
+  - `--replace-exclude-dirs` — replace the default excluded set entirely.
+  - `--exclude-files` — comma-separated globs or exact paths (absolute or project-relative).
+  - `-X, --exclude-extensions` — extension denylist (wins over `-x`).
+  - `-x, --extensions` — extension allowlist (replaces the default “programming-like” set).
+  - `--self` — include `all_code.py` in output (hidden by default to avoid self-inclusion).
 
-```shell
+- **Tree < - > aggregation consistency**
+  - Default excluded dirs (e.g. `node_modules`, `.venv`) are shown once with `[EXCLUDED]` and not traversed.
+  - Files excluded via `--exclude-files` or `-X` are marked `[EXCLUDED]` in the tree so it’s obvious why they’re missing later.
+
+> None of these change defaults for existing users; they’re opt-in.
+
+## Install
+
+**From GitHub (original project)**
+
+```bash
 pip install git+https://github.com/foxalabs/all_code@0.4.0
-```
+# from a local clone
 
-2. **From local directory**
-
-To install from a local directory, use edit mode so your code changes are reflected immediately. This is useful for development/debugging mode.
-
-```shell
 git clone https://github.com/foxalabs/all_code.git
 cd all_code
 pip install -e .
-```
 
-## Usage
 
-**Basic usage**
 
-```bash
+# Usage
+
+'''bash
 all-code
-```
+'''
 
-**Specify a Directory**
+## Specify directory
 
-```bash
-all-code -d /path/to/start/directory
-```
+'''bash
+all-code -d /path/to/project
+'''
 
-**Copy Aggregated Content to Clipboard Instead of Writing to File** (macOS and Windows 10+)
+## Copy to clipboard (macOS / Windows 10+)
 
-```bash
-all-code -c
-```
+'''bash
+all-code -d /path/to/project -c
+'''
 
-**Combine Both Arguments: Specify Directory and Copy to Clipboard**
+## Write to a subfolder of directory
 
-```bash
-all-code -d /path/to/start/directory -c
-```
+'''bash
+# mkdir -p tests
+all-code -d /path/to/project . -o tests/out.txt
 
-**Exclude Specific File Extensions**
+## Exclude by glob or exact path
 
-```bash
-all-code -X .json,.md,.html
-```
+'''bash
+all-code -d /path/to/project --exclude-files "foo/*.json,**/secrets.*"
+'''
 
-**Combine Multiple Options: Specify Directory, Copy to Clipboard, and Exclude Extensions**
+## Allowlist extensions (denylist wins if both set)
 
-```bash
-all-code -d /path/to/start/directory -c -X .json,.md,.html
-```
+'''bash
+all-code -d /path/to/project -x ".py,.ts" -X ".py"
+'''
 
-**More options**
+## Add more excluded dirs (keeps defaults)
 
-```bash
-all-code --help
-usage: all_code.py [-h] [-c] [-d DIRECTORY] [-o OUTPUT_FILE] [-i INCLUDE_FILES] [-x EXTENSIONS] [-e EXCLUDE_DIRS]
+'''bash
+all-code -d /path/to/project -e "secret,bar"
+'''
 
-Aggregate code files into a master file with a directory tree.
+## Replace default excluded dirs entirely
 
-options:
-  -h, --help            show this help message and exit
-  -c, --clipboard       Copy the aggregated content to the clipboard instead of writing to a file.
-  -d, --directory DIRECTORY
-                        Specify the directory to start aggregation from. Defaults to the current working directory.
-  -o, --output-file OUTPUT_FILE
-                        Name of the output file. Defaults to full_code.txt.
-  -i, --include-files INCLUDE_FILES
-                        Comma-separated list of files to include. If not provided, all files are included.
-  -x, --extensions EXTENSIONS
-                        Comma-separated list of programming extensions to use. Replaces the default set if provided.
-  -e, --exclude-dirs EXCLUDE_DIRS
-                        Comma-separated directory names or paths to additionally exclude.
-      --replace-exclude-dirs
-                        Replace the default excluded directories entirely with those from -e.
-      --exclude-files EXCLUDE_FILES
-                        Comma-separated file paths or globs to exclude (abs or project-relative).
-  -X, --exclude-extensions EXCLUDE_EXTENSIONS
-                        Comma-separated list of file extensions to exclude from aggregation.
-```
+'''bash
+all-code -d /path/to/project --replace-exclude-dirs -e "my_generated,build-cache"
+'''
 
-## Exclusions
+## Include the tool itself
 
-The **All Code Aggregator** script automatically excludes specific directories and files to streamline the aggregation process and avoid including unnecessary or sensitive information.
+'''bash
+all-code --self
+'''
 
-### Excluded Directories
-
-The following directories are excluded by default:
-
-- `venv`
-- `.venv`
-- `node_modules`
-- `__pycache__`
-- `.git`
-- `dist`
-- `build`
-- `temp`
-- `old_files`
-- `flask_session`
-
-**Purpose**: These directories are typically used for virtual environments, dependencies, build artifacts, version control, or temporary files that are not part of the core codebase.
-
-### Excluded Extensions
-
-Users can now exclude specific file extensions using the `-X` or `--exclude-extensions` argument.
-
-**Example:**
-
-```bash
-all-code -X .json,.md,.html
-all-code --exclude-files "config/*.json,**/secrets.*"
-all-code --replace-exclude-dirs -e "my_generated,build-cache"
-```
-
-This will exclude all .json, .md, and .html files from aggregation.
-
-## Example Output to full_code.txt
-
-```
+# Output format
+'''php
 Directory Tree:
-all_code/
-│   ├── full_code.txt
-│   ├── README.md
-│   ├── test.py
-│   ├── .git/ [EXCLUDED]
-│   ├── demo_folder/
-│   │   ├── another_file.js
-
-
-
+project/
+│   ├── src/
+│   │   ├── main.py
+│   ├── node_modules/ [EXCLUDED]
 
 # ======================
-# File: test.py
+# File: src/main.py
 # ======================
 
-def greet(name):
-    return f"Hello, {name}!"
+print("hello world")
+'''
 
-if __name__ == "__main__":
-    print(greet("World"))
-    def farewell(name):
-        return f"Goodbye, {name}!"
+# Defaults & Notes
+Default excluded directories (not traversed): node_modules, .venv, venv, __pycache__, .git, dist, build, temp, old_files, flask_session.
 
-    print(farewell("World"))
+By default, only “programming-like” extensions are aggregated. Use -x to override or -X to deny specific extensions.
 
-# ======================
-# File: demo_folder\another_file.js
-# ======================
+Clipboard support is implemented for macOS (pbcopy) and Windows (clip).
 
-// another_file.js
+# Testing
+Run the following command
 
-// Function to add two numbers
-function add(a, b) {
-    return a + b;
-}
-
-// Function to subtract two numbers
-function subtract(a, b) {
-    return a - b;
-}
-
-// Function to multiply two numbers
-function multiply(a, b) {
-    return a * b;
-}
-
-// Function to divide two numbers
-function divide(a, b) {
-    if (b === 0) {
-        throw new Error("Division by zero is not allowed.");
-    }
-    return a / b;
-}
-
-// Example usage
-console.log("Add: " + add(5, 3));         // Output: Add: 8
-console.log("Subtract: " + subtract(5, 3)); // Output: Subtract: 2
-console.log("Multiply: " + multiply(5, 3)); // Output: Multiply: 15
-console.log("Divide: " + divide(5, 3));     // Output: Divide: 1.6666666666666667
-```
-
-## Testing the script
-
-If you want to test the script, run the following command.
-
-```bash
+'''bash
 python test_all_code.py
-```
+'''
 
-As of the current commit, only the command line args and their effects were tested, but more tests can be added in the future.
+# Changelog (this PR)
+Directory tree now marks user-excluded files with [EXCLUDED].
+
+Allow file address exlusion in addition to file name exclusion.
+
+Add --exclude-files, --replace-exclude-dirs, --self.
+
+Make -e additive by default (use --replace-exclude-dirs to replace).
+
+Clarify precedence: -X (denylist) beats -x (allowlist).
+```

--- a/README.md
+++ b/README.md
@@ -1,31 +1,55 @@
 # All Code Aggregator
 
-Aggregate source files into a single text file that starts with a compact directory tree, followed by file-by-file sections. Great for sharing a self-contained snapshot with tools or reviewers.
+Snapshot your project into one readable text file: a compact directory tree followed by file-by-file sections. Perfect for review packets, sharing with AI tools, or quick audits.
 
 ---
 
-## What’s in this PR (exclusions + clarity)
+# What’s new in this PR (exclusions + clarity)
 
-This fork focuses on **exclusion controls** and a few quality-of-life improvements:
+## Excluding directories via -e
 
-- **Output convenience**
-  - `-o` accepts a subpath (create the folder first): `-o tests/out.txt`.
-- **New/clarified options**
+- Previously: -e replaced the entire default excluded set (could accidentally re-include node_modules/.venv if you weren’t careful).
+- Now: -e is additive by default; use --replace-exclude-dirs to replace the set intentionally.
 
-  - `-e, --exclude-dirs` — add names or **paths** to exclude (**additive**).
-  - `--replace-exclude-dirs` — **replace** the default excluded set entirely.
-  - `--exclude-files` — comma-separated **globs** or **exact paths** (absolute or project-relative).
-  - `-X, --exclude-extensions` — extension denylist (wins over `-x`).
-  - `-x, --extensions` — extension allowlist (_replaces_ the default set “programming-like” set).
-  - `--self` — include `all_code.py` in output (hidden by default to avoid self-inclusion).
+## What the directory tree shows
 
-- **Tree < - > aggregation consistency**
-  - Default excluded dirs (e.g. `node_modules`, `.venv`) are shown once with `[EXCLUDED]` and not traversed.
-  - Files excluded via `--exclude-files` or `-X` are marked `[EXCLUDED]` in the tree so it’s obvious why they’re missing later.
+- Previously: Only default-excluded dirs (like node_modules, .venv) were tagged [EXCLUDED]; individual files excluded by flags weren’t called out in the tree.
+- Now: Files excluded via --exclude-files or -X are marked [EXCLUDED] in the tree so readers see why they’re missing from aggregation.
 
-> None of these change defaults for existing users; they’re opt-in.
+## Which directories can be excluded
 
-## Install
+- Previously: Exclusion was based on directory names supplied via -e and a fixed default name set.
+- Now: -e accepts names or paths; you can exclude by name or path-prefix, and you can replace the defaults via --replace-exclude-dirs.
+
+## File-level excludes
+
+- Previously: No --exclude-files flag; exclusion was directory-based (plus extension denylist via -X).
+- Now: --exclude-files supports comma-separated globs or exact paths (absolute or project-relative).
+
+## Extension rules
+
+- Previously: -x (allowlist) replaced the entire default set of allowed extension. Denylist precedence was not made clear.
+- Now: Documented precedence: -X (denylist) overrides -x (allowlist). Clearer mental model.
+
+## Output path convenience
+
+- Previously: -o could point to a subpath if it already existed (not documented clearly).
+- Now: Documented: -o accepts a subpath; create the folder first (e.g., -o tests/output.txt).
+
+## Test runner portability (developer experience)
+
+Previously: Tests invoked “python” directly (could call the wrong interpreter).
+Now: Tests invoke sys.executable so they use the active interpreter (virtualenv-friendly).
+
+> None of these change defaults; they’re opt-in” immediately after the changes block for emphasis.
+
+## Additional details of changes
+
+- Files excluded due to a user-specified extension exclusion are marked as [EXCLUDED] in the tree overview and not traversed.
+- Default excluded dirs (e.g. `node_modules`, `.venv`) are also marked once with `[EXCLUDED]` and not traversed.
+- `--self` — include `all_code.py` in output (hidden by default to avoid self-inclusion).
+
+## Installation
 
 **From GitHub (original project)**
 
@@ -35,16 +59,24 @@ cd all_code
 pip install -e .
 ```
 
-# Usage
+Install this PR from my fork (for reviewers)
 
 ```bash
-all-code
+pip install git+https://github.com/hamzadev3/all_code@feature/exclusions.git
+```
+
+# Usage
+
+## Help
+
+```bash
+all-code --help
 ```
 
 ## Specify directory
 
 ```bash
-all-code -d /path/to/project
+all-code -d /path/to/project -o output.txt
 ```
 
 ## Copy to clipboard (macOS / Windows 10+)
@@ -53,46 +85,56 @@ all-code -d /path/to/project
 all-code -d /path/to/project -c
 ```
 
-## Write to a subfolder of directory
+## Output to a subfolder of directory
 
 ```bash
-# mkdir -p tests
-all-code -d /path/to/project . -o tests/out.txt
+mkdir -p tests
+all-code -d /path/to/project -o tests/output.txt
 ```
 
 ## Exclude by glob or exact path
 
 ```bash
-all-code -d /path/to/project --exclude-files "foo/*.json,**/secrets.*"
+all-code -d /path/to/project -o output.txt --exclude-files "foo/*.json,**/secrets.*"
+```
+
+## Replace all default exclusions entirely, then add your own exclusion
+
+```bash
+all-code -d /path/to/project -o output.txt --replace-exclude-dirs -e "my_generated,build-cache"
 ```
 
 ## Allowlist extensions (denylist wins if both set)
 
 ```bash
-all-code -d /path/to/project -x ".py,.ts" -X ".py"
+all-code -d /path/to/project -o output.txt -x ".py,.ts"
+all-code -d /path/to/project -o output.txt -X ".py"
 ```
+
+- `-x` allows extensions that may have been left out of the hardcoded set of accepted extensions
+- `-X` denies them. In this case, -X takes priority
 
 ## Add more excluded dirs (keeps defaults)
 
 ```bash
-all-code -d /path/to/project -e "secret,bar"
+all-code -d /path/to/project -o output.txt -e "secret,bar"
 ```
 
 ## Replace default excluded dirs entirely
 
 ```bash
-all-code -d /path/to/project --replace-exclude-dirs -e "my_generated,build-cache"
+all-code -d /path/to/project -o output.txt --replace-exclude-dirs -e "my_generated,build-cache"
 ```
 
 ## Include the tool itself
 
 ```bash
-all-code --self
+all-code -o output.txt --self
 ```
 
 # Output format
 
-```php
+```
 Directory Tree:
 project/
 │   ├── src/
@@ -108,7 +150,7 @@ print("hello world")
 
 # Defaults & Notes
 
-- Default excluded directories (not traversed): node_modules, .venv, venv, **pycache**, .git, dist, build, temp, old_files, flask_session.
+- Default excluded directories (not traversed): node\*modules, .venv, venv, pycache, .git, dist, build, temp, old_files, flask_session.
 
 - By default, only “programming-like” extensions are aggregated. Use -x to override or -X to deny specific extensions.
 
@@ -126,10 +168,10 @@ python test_all_code.py
 
 - Directory tree now marks user-excluded files with [EXCLUDED].
 
-- Allow file address exlusion in addition to file name exclusion.
+- Allow file path exlusion in addition to file name exclusion.
 
 - Add --exclude-files, --replace-exclude-dirs, --self.
 
-- Make -e additive by default (use --replace-exclude-dirs to replace).
+- Make -e additive by default (use --replace-exclude-dirs to replace the entire directory).
 
 - Clarity: -X (denylist) beats -x (allowlist).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # All Code Aggregator
 
 Snapshot your project into one readable text file: a compact directory tree followed by file-by-file sections. Perfect for review packets, sharing with AI tools, or quick audits.
+This is a focused PR on exclusion controls and clarity.
 
 ---
 
@@ -41,7 +42,7 @@ Snapshot your project into one readable text file: a compact directory tree foll
 Previously: Tests invoked “python” directly (could call the wrong interpreter).
 Now: Tests invoke sys.executable so they use the active interpreter (virtualenv-friendly).
 
-> None of these change defaults; they’re opt-in” immediately after the changes block for emphasis.
+> None of these change defaults; they’re opt-in immediately after the changes block for emphasis.
 
 ## Additional details of changes
 
@@ -62,7 +63,7 @@ pip install -e .
 Install this PR from my fork (for reviewers)
 
 ```bash
-pip install git+https://github.com/hamzadev3/all_code@feature/exclusions.git
+pip install git+https://github.com/hamzadev3/all_code@feature/exclusions
 ```
 
 # Usage
@@ -150,7 +151,7 @@ print("hello world")
 
 # Defaults & Notes
 
-- Default excluded directories (not traversed): node\*modules, .venv, venv, pycache, .git, dist, build, temp, old_files, flask_session.
+- Default excluded directories (not traversed): node_modules, .venv, venv, pycache, .git, dist, build, temp, old_files, flask_session.
 
 - By default, only “programming-like” extensions are aggregated. Use -x to override or -X to deny specific extensions.
 
@@ -168,7 +169,7 @@ python test_all_code.py
 
 - Directory tree now marks user-excluded files with [EXCLUDED].
 
-- Allow file path exlusion in addition to file name exclusion.
+- Allow file path exclusion in addition to file name exclusion.
 
 - Add --exclude-files, --replace-exclude-dirs, --self.
 

--- a/all_code.py
+++ b/all_code.py
@@ -18,6 +18,7 @@ import subprocess
 import pathlib
 import fnmatch
 
+
 # Define the master file name
 FULL_CODE_FILE_NAME = "full_code.txt"
 
@@ -94,6 +95,7 @@ PROGRAMMING_EXTENSIONS = {
 
 # Define directories to exclude during file aggregation and directory tree generation
 DEFAULT_EXCLUDED_DIRS = {
+    '''
     "venv",
     ".venv",
     "node_modules",
@@ -104,58 +106,96 @@ DEFAULT_EXCLUDED_DIRS = {
     "temp",
     "old_files",
     "flask_session",
+    '''
 }
 
 # Define the name of this script to exclude it
 SCRIPT_NAME = os.path.basename(__file__)
 
 # Define files to exclude from both aggregation and directory tree
-EXCLUDE_FILES = {SCRIPT_NAME, "package-lock.json", "package.json", "temp.py"}
+EXCLUDE_FILES = {"package-lock.json", "package.json", "temp.py"}
 
 
-def generate_directory_tree(startpath, should_skip_dir):
+def generate_directory_tree(startpath, should_skip_dir, is_tree_excluded_file=None):
     """
     Generates an ASCII directory tree.
     - Excluded directories and their subdirectories are listed once and marked [EXCLUDED].
-    - The script itself is excluded from the tree.
-    Uses the provided should_skip_dir(dirpath) for exclusion logic.
+    - Files are listed once; if a file is user-excluded, it is shown as [EXCLUDED].
     """
     tree = ""
     for root, dirs, files in os.walk(startpath):
-        # Determine the relative path from the startpath
+        # compute path pieces / indent
         rel_path = os.path.relpath(root, startpath)
         if rel_path == ".":
             rel_path = ""
-
-        # Split the relative path into parts
-        path_parts = rel_path.split(os.sep) if rel_path else []
-
-        # Calculate the level of depth
-        level = len(path_parts)
+        level = len(rel_path.split(os.sep)) if rel_path else 0
         indent = "│   " * level + "├── " if level > 0 else ""
 
-        # Add the current directory to the tree
         current_dir = (
             os.path.basename(root)
             if rel_path
             else os.path.basename(startpath.rstrip(os.sep)) or startpath
         )
 
-        # New: use should_skip_dir to decide whether to prune/display as EXCLUDED
+        # directory-level exclusion
         if should_skip_dir(root):
             tree += f"{indent}{current_dir}/ [EXCLUDED]\n"
-            dirs[:] = []  # Prevent os.walk from traversing further
+            dirs[:] = []  # don't descend
             continue
 
         tree += f"{indent}{current_dir}/\n"
 
-        # List files, excluding the script itself and any in EXCLUDE_FILES
         for f in files:
             if f in EXCLUDE_FILES:
-                continue  # Skip excluded files
-            tree += f"{'│   ' * (level + 1)}├── {f}\n"
+                continue  # hide internal/always-excluded files from the tree
+
+            path = os.path.join(root, f)
+            # Decide if this file should be *marked* excluded in the tree.
+            # IMPORTANT: do not mark non-programming files as excluded just because
+            # they won't be aggregated; only mark files explicitly excluded by user controls.
+            excluded_in_tree = False
+            if is_tree_excluded_file is not None:
+                excluded_in_tree = is_tree_excluded_file(path)
+
+            suffix = " [EXCLUDED]" if excluded_in_tree else ""
+            tree_line = f"{'│   ' * (level + 1)}├── {f}{suffix}\n"
+            tree += tree_line
 
     return tree
+
+# New helper: decide if a file should appear as [EXCLUDED] in the tree.
+# Only explicit user controls should show "[EXCLUDED]" tags:
+#  - --exclude-files matches (glob or exact)
+#  - -X/--exclude-extensions matches
+def make_is_tree_excluded_file(exclude_file_globs, excluded_exts, startpath):
+    """
+    Tree-exclusion predicate. Used by the directory-tree printer only.
+    Non-programming files are *not* tagged excluded just because they won't be aggregated.
+    """
+    
+    def _pred(filepath: str) -> bool:
+        # extension-based denylist (user-provided -X)
+        _, ext = os.path.splitext(filepath)
+        ext = ext.lower()
+        if ext and ext in excluded_exts:
+            return True
+
+        # --exclude-files globs or exact paths (abs or project-relative)
+        if exclude_file_globs:
+            abs_path = os.path.abspath(filepath)
+            rel_path = os.path.relpath(filepath, startpath)
+            for pat in exclude_file_globs:
+                if (
+                    fnmatch.fnmatch(abs_path, pat)
+                    or fnmatch.fnmatch(rel_path, pat)
+                    or abs_path == pat
+                    or rel_path == pat
+                ):
+                    return True
+
+        return False
+
+    return _pred
 
 
 def is_programming_file(filename):
@@ -169,6 +209,7 @@ def should_exclude(path):
     # Determines if a file should be excluded based on its path.
     # - Excludes files in EXCLUDE_DIRS and their subdirectories.
     # - Excludes files listed in EXCLUDE_FILES.
+    # legacy function
 
     # Normalize path separators
     normalized_path = os.path.normpath(path)
@@ -259,12 +300,14 @@ def parse_arguments():
         default="",
         help="Comma-separated file paths or globs to exclude.",
     )
+    parser.add_argument("--self", action="store_true", help="Include all_code.py in tree/aggregation. all_code.py is excluded by default to avoid inclusion of the working script behind this tool.")
 
     return parser.parse_args()
 
 
 # Helper to remove whitespace
 def _split_csv(s: str):
+    """Split a comma-separated string, stripping *all* whitespace (incl. NBSP)."""
     if not s:
         return []
     parts = []
@@ -274,7 +317,6 @@ def _split_csv(s: str):
         if p:
             parts.append(p)
     return parts
-
 
 # TODO: Works on MacOS and Windows 10+. Linux support can be added later
 def copy_to_clipboard(content):
@@ -324,6 +366,11 @@ def main():
         EXCLUDE_EXTENSIONS = {
             ext.strip() for ext in args.exclude_extensions.split(",") if ext.strip()
         }
+        
+    # Users may include this script in output via --self.
+    # By default we hide it to prevent the tool from including itself.
+    if not args.self:
+        EXCLUDE_FILES.add(SCRIPT_NAME)
 
     # Debugging print statement to verify exclusions
     print(f"Excluding extensions: {EXCLUDE_EXTENSIONS}")
@@ -335,11 +382,8 @@ def main():
         )
         sys.exit(1)
 
-    # -------------------------
-    # Added build exclusion logic (additive -e, path-aware -e, per-file excludes)
-    # -------------------------
-
-    # 1) Effective excluded directories (additive by default)
+    # Build the effective directory exclusion set.
+    # Default is additive: defaults ∪ user list. Use --replace-exclude-dirs to replace.
     user_excluded = set(_split_csv(args.exclude_dirs))
     effective_excluded = (
         user_excluded
@@ -367,6 +411,7 @@ def main():
 
     # 3) File-level excludes (exact and glob)
     exclude_file_globs = _split_csv(args.exclude_files)
+    
 
     # 4) Extension sets (NBSP-safe)
     excluded_exts = set(_split_csv(args.exclude_extensions))
@@ -376,6 +421,7 @@ def main():
 
     # 5) Helpers used by tree and aggregation
     def should_skip_dir(dirpath: str) -> bool:
+        """Return True if a directory should not be traversed (name match or path-prefix match)."""
         base = os.path.basename(dirpath.rstrip(os.sep))
         if base in exclude_dir_names:
             return True
@@ -386,7 +432,21 @@ def main():
             rp = os.path.abspath(dirpath)
         return any(rp.startswith(pref) for pref in exclude_dir_prefixes)
 
+    is_tree_excluded_file = make_is_tree_excluded_file(
+        exclude_file_globs, excluded_exts, startpath
+    )
+    directory_tree = generate_directory_tree(
+        startpath, should_skip_dir, is_tree_excluded_file
+    )
     def should_skip_file(filepath: str) -> bool:
+        """
+        Return True if a file must be skipped by the aggregator:
+        - extension denylist (-X)
+        - not in allowed extension allowlist
+        - matches --exclude-files (abs or project-relative)
+        - legacy exclude set (EXCLUDE_FILES)
+        """
+        
         # extension-based exclusions
         _, ext = os.path.splitext(filepath)
         ext = ext.lower()
@@ -411,11 +471,11 @@ def main():
             return True
         return False
 
-    # Generate directory tree (using new exclusion logic)
-    directory_tree = generate_directory_tree(startpath, should_skip_dir)
-
+    # Two-pass approach:
+    #  1) print the tree (with explicit [EXCLUDED] tags for user-excludes)
+    #  2) walk again to aggregate file contents (pruning excluded dirs)
     aggregated_content = "Directory Tree:\n" + directory_tree + "\n\n"
-
+    
     # Traverse the directory again to process files
     for root, dirs, files in os.walk(startpath):
         # NEW: prune directories in-place so os.walk does not descend into excluded dirs
@@ -453,6 +513,7 @@ def main():
                 error_msg = f"\n# Error reading file {rel_file_path}: {e}\n"
                 aggregated_content += error_msg
 
+
     if args.clipboard:
         # Copy the aggregated content to the clipboard
         success = copy_to_clipboard(aggregated_content)
@@ -472,6 +533,7 @@ def main():
         except Exception as e:
             print(f"Error writing to file '{FULL_CODE_FILE_NAME}': {e}")
             sys.exit(1)
+    # after the big for-root,dirs,files loop that adds file contents:
 
 
 if __name__ == "__main__":

--- a/all_code.py
+++ b/all_code.py
@@ -95,7 +95,6 @@ PROGRAMMING_EXTENSIONS = {
 
 # Define directories to exclude during file aggregation and directory tree generation
 DEFAULT_EXCLUDED_DIRS = {
-    '''
     "venv",
     ".venv",
     "node_modules",
@@ -106,7 +105,6 @@ DEFAULT_EXCLUDED_DIRS = {
     "temp",
     "old_files",
     "flask_session",
-    '''
 }
 
 # Define the name of this script to exclude it

--- a/all_code.py
+++ b/all_code.py
@@ -30,47 +30,85 @@ EXCLUDE_EXTENSIONS = set()  # User-defined extensions to exclude
 # Define programming-related file extensions (removed '.json' and '.md')
 PROGRAMMING_EXTENSIONS = {
     # General Programming Languages
-    '.py', '.java', '.c', '.cpp', '.h', '.hpp', '.cs', '.vb', '.r', 
-    '.rb', '.go', '.php', '.swift', '.kt', '.rs', '.scala', '.pl', '.lua', '.jl'
-
+    ".py",
+    ".java",
+    ".c",
+    ".cpp",
+    ".h",
+    ".hpp",
+    ".cs",
+    ".vb",
+    ".r",
+    ".rb",
+    ".go",
+    ".php",
+    ".swift",
+    ".kt",
+    ".rs",
+    ".scala",
+    ".pl",
+    ".lua",
+    ".jl"
     # Web Development
-    '.js', '.jsx', '.ts', '.tsx', '.html', '.css', '.scss', '.less', '.sass',
-
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".html",
+    ".css",
+    ".scss",
+    ".less",
+    ".sass",
     # Shell & Automation
-    '.sh', '.zsh', '.fish', '.ps1', '.bat', '.cmd',
-
+    ".sh",
+    ".zsh",
+    ".fish",
+    ".ps1",
+    ".bat",
+    ".cmd",
     # Database & Query Languages
-    '.sql', '.psql', '.db', '.sqlite',
-
+    ".sql",
+    ".psql",
+    ".db",
+    ".sqlite",
     # Markup & Config Files
-    '.xml', '.json', '.toml', '.ini', '.yml', '.yaml', '.md', '.rst',
-
+    ".xml",
+    ".json",
+    ".toml",
+    ".ini",
+    ".yml",
+    ".yaml",
+    ".md",
+    ".rst",
     # Build & Make Systems
-    '.Makefile', '.gradle', '.cmake', '.ninja',
-
+    ".Makefile",
+    ".gradle",
+    ".cmake",
+    ".ninja",
     # Other
-    '.pqm', '.pq'
+    ".pqm",
+    ".pq",
 }
 
 # Define directories to exclude during file aggregation and directory tree generation
 EXCLUDE_DIRS = {
-    'venv',
-    '.venv',
-    'node_modules',
-    '__pycache__',
-    '.git',
-    'dist',
-    'build',
-    'temp',
-    'old_files',
-    'flask_session'
+    "venv",
+    ".venv",
+    "node_modules",
+    "__pycache__",
+    ".git",
+    "dist",
+    "build",
+    "temp",
+    "old_files",
+    "flask_session",
 }
 
 # Define the name of this script to exclude it
 SCRIPT_NAME = os.path.basename(__file__)
 
 # Define files to exclude from both aggregation and directory tree
-EXCLUDE_FILES = {SCRIPT_NAME, 'package-lock.json', 'package.json', 'temp.py'}
+EXCLUDE_FILES = {SCRIPT_NAME, "package-lock.json", "package.json", "temp.py"}
 
 
 def generate_directory_tree(startpath):
@@ -83,19 +121,22 @@ def generate_directory_tree(startpath):
     for root, dirs, files in os.walk(startpath):
         # Determine the relative path from the startpath
         rel_path = os.path.relpath(root, startpath)
-        if rel_path == '.':
-            rel_path = ''
+        if rel_path == ".":
+            rel_path = ""
 
         # Split the relative path into parts
         path_parts = rel_path.split(os.sep) if rel_path else []
 
         # Calculate the level of depth
         level = len(path_parts)
-        indent = '│   ' * level + '├── ' if level > 0 else ''
+        indent = "│   " * level + "├── " if level > 0 else ""
 
         # Add the current directory to the tree
-        current_dir = os.path.basename(root) if rel_path else os.path.basename(
-            startpath.rstrip(os.sep)) or startpath
+        current_dir = (
+            os.path.basename(root)
+            if rel_path
+            else os.path.basename(startpath.rstrip(os.sep)) or startpath
+        )
 
         # Check if the current directory is excluded
         if current_dir in EXCLUDE_DIRS:
@@ -119,7 +160,6 @@ def is_programming_file(filename):
     _, ext = os.path.splitext(filename)
     ext = ext.lower()
     return ext in PROGRAMMING_EXTENSIONS and ext not in EXCLUDE_EXTENSIONS
-
 
 
 def should_exclude(path):
@@ -159,36 +199,106 @@ def parse_arguments():
     Parses command-line arguments.
     """
     parser = argparse.ArgumentParser(
-        description="Aggregate code files into a master file with a directory tree.")
-    parser.add_argument('-c', '--clipboard', action='store_true',
-                        help="Copy the aggregated content to the clipboard instead of writing to a file.")
-    parser.add_argument('-d', '--directory', type=str, default=os.getcwd(),
-                        help="Specify the directory to start aggregation from. Defaults to the current working directory.")
-    parser.add_argument('-o', '--output-file', type=str, default=FULL_CODE_FILE_NAME,
-                        help="Name of the output file. Defaults to full_code.txt.")
-    parser.add_argument('-i', '--include-files', type=str, default="",
-                        help="Comma-separated list of files to include. If not provided, all files are included.")
-    parser.add_argument('-x', '--extensions', type=str, default="",
-                        help="Comma-separated list of programming extensions to use. Replaces the default set if provided.")
-    parser.add_argument('-e', '--exclude-dirs', type=str, default="",
-                        help="Comma-separated list of directories to exclude. Replaces the default set if provided.")
-    parser.add_argument('-X', '--exclude-extensions', type=str, default="",
-                    help="Comma-separated list of file extensions to exclude.")
+        description="Aggregate code files into a master file with a directory tree."
+    )
+    parser.add_argument(
+        "-c",
+        "--clipboard",
+        action="store_true",
+        help="Copy the aggregated content to the clipboard instead of writing to a file.",
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        type=str,
+        default=os.getcwd(),
+        help="Specify the directory to start aggregation from. Defaults to the current working directory.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-file",
+        type=str,
+        default=FULL_CODE_FILE_NAME,
+        help="Name of the output file. Defaults to full_code.txt.",
+    )
+    parser.add_argument(
+        "-i",
+        "--include-files",
+        type=str,
+        default="",
+        help="Comma-separated list of files to include. If not provided, all files are included.",
+    )
+    parser.add_argument(
+        "-x",
+        "--extensions",
+        type=str,
+        default="",
+        help="Comma-separated list of programming extensions to use. Replaces the default set if provided.",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude-dirs",
+        type=str,
+        default="",
+        help="Comma-separated list of directories to exclude. Replaces the default set if provided.",
+    )
+    parser.add_argument(
+        "-X",
+        "--exclude-extensions",
+        type=str,
+        default="",
+        help="Comma-separated list of file extensions to exclude.",
+    )
+    """
+    Additional parser arguments:  
+    """
+    parser.add_argument(
+        "-e",
+        "--exclude-dirs",
+        default="",
+        help="Comma-separated directory names or paths to additionally exclude files.",
+    )
+    parser.add_argument(
+        "--replace-exclude-dirs",
+        action="store_true",
+        help="Replace default excluded directories with the list from -e.",
+    )
+    parser.add_argument(
+        "--exclude-files",
+        default="",
+        help="Comma-separated file paths or globs to exclude.",
+    )
+
     return parser.parse_args()
+
+
+# Helper to remove whitespace
+def _split_csv(s: str):
+    if not s:
+        return []
+    parts = []
+    for raw in s.split(","):
+        p = "".join(ch for ch in raw if not ch.isspace())
+        if p:
+            parts.append(p)
+    return parts
+
 
 # TODO: Works on MacOS and Windows 10+. Linux support can be added later
 def copy_to_clipboard(content):
     """Copy text to the system clipboard on macOS and Windows."""
     try:
-        if sys.platform == 'darwin':
-            process = subprocess.Popen('pbcopy', env={'LANG': 'en_US.UTF-8'}, stdin=subprocess.PIPE)
-            process.communicate(content.encode('utf-8'))
+        if sys.platform == "darwin":
+            process = subprocess.Popen(
+                "pbcopy", env={"LANG": "en_US.UTF-8"}, stdin=subprocess.PIPE
+            )
+            process.communicate(content.encode("utf-8"))
             return process.returncode == 0
-        elif sys.platform.startswith('win'):
+        elif sys.platform.startswith("win"):
             # Windows 10+ ships with the 'clip' utility
-            process = subprocess.Popen('clip', stdin=subprocess.PIPE, shell=True)
+            process = subprocess.Popen("clip", stdin=subprocess.PIPE, shell=True)
             # clip expects UTF-16LE encoding
-            process.communicate(content.encode('utf-16le'))
+            process.communicate(content.encode("utf-16le"))
             return process.returncode == 0
         else:
             print("Clipboard copy is only supported on macOS and Windows 10+.")
@@ -196,6 +306,7 @@ def copy_to_clipboard(content):
     except Exception as e:
         print(f"Error copying to clipboard: {e}")
         return False
+
 
 def main():
     args = parse_arguments()
@@ -208,28 +319,37 @@ def main():
 
     if args.include_files:
         # Split the comma-separated string and remove any extra whitespace.
-        FILES_TO_INCLUDE = {f.strip() for f in args.include_files.split(',') if f.strip()}
+        FILES_TO_INCLUDE = {
+            f.strip() for f in args.include_files.split(",") if f.strip()
+        }
 
     if args.extensions:
-        PROGRAMMING_EXTENSIONS = {ext.strip() for ext in args.extensions.split(',') if ext.strip()}
+        PROGRAMMING_EXTENSIONS = {
+            ext.strip() for ext in args.extensions.split(",") if ext.strip()
+        }
 
     if args.exclude_dirs:
-        EXCLUDE_DIRS = {d.strip() for d in args.exclude_dirs.split(',') if d.strip()}
-        
-    if args.exclude_extensions:
-        EXCLUDE_EXTENSIONS = {ext.strip() for ext in args.exclude_extensions.split(',') if ext.strip()}
+        EXCLUDE_DIRS = {d.strip() for d in args.exclude_dirs.split(",") if d.strip()}
 
+    if args.exclude_extensions:
+        EXCLUDE_EXTENSIONS = {
+            ext.strip() for ext in args.exclude_extensions.split(",") if ext.strip()
+        }
 
     # Debugging print statement to verify exclusions
     print(f"Excluding extensions: {EXCLUDE_EXTENSIONS}")
     startpath = args.directory
 
     if not os.path.isdir(startpath):
-        print(f"Error: The specified directory '{startpath}' does not exist or is not a directory.")
+        print(
+            f"Error: The specified directory '{startpath}' does not exist or is not a directory."
+        )
         sys.exit(1)
 
     if not os.path.isdir(startpath):
-        print(f"Error: The specified directory '{startpath}' does not exist or is not a directory.")
+        print(
+            f"Error: The specified directory '{startpath}' does not exist or is not a directory."
+        )
         sys.exit(1)
 
     # Generate directory tree
@@ -241,8 +361,8 @@ def main():
     for root, dirs, files in os.walk(startpath):
         # Determine the relative path from the startpath
         rel_path = os.path.relpath(root, startpath)
-        if rel_path == '.':
-            rel_path = ''
+        if rel_path == ".":
+            rel_path = ""
 
         # Split the relative path into parts
         path_parts = rel_path.split(os.sep) if rel_path else []
@@ -254,27 +374,30 @@ def main():
             continue
 
         # Check if the current directory is excluded
-        current_dir = os.path.basename(root) if rel_path else os.path.basename(
-            startpath.rstrip(os.sep)) or startpath
+        current_dir = (
+            os.path.basename(root)
+            if rel_path
+            else os.path.basename(startpath.rstrip(os.sep)) or startpath
+        )
         if current_dir in EXCLUDE_DIRS:
             dirs[:] = []  # Prevent os.walk from traversing further
             continue
 
         for file in files:
-            
+
             file_path = os.path.join(root, file)
-            
+
             # Get file extension
             _, ext = os.path.splitext(file)
             ext = ext.lower()
 
             # Skip files with excluded extensions
             if ext in EXCLUDE_EXTENSIONS:
-                continue  
+                continue
 
             # Skip non-programming files
             if not is_programming_file(file):
-                continue 
+                continue
             # Get relative path for exclusion and headers
             rel_file_path = os.path.relpath(file_path, startpath)
 
@@ -285,7 +408,7 @@ def main():
             aggregated_content += header
 
             try:
-                with open(file_path, 'r', encoding='utf-8') as f:
+                with open(file_path, "r", encoding="utf-8") as f:
                     content = f.read()
                     aggregated_content += content
             except Exception as e:
@@ -303,9 +426,11 @@ def main():
     else:
         # Write the aggregated content to the master file
         try:
-            with open(FULL_CODE_FILE_NAME, 'w', encoding='utf-8') as master_file:
+            with open(FULL_CODE_FILE_NAME, "w", encoding="utf-8") as master_file:
                 master_file.write(aggregated_content)
-            print(f"Full code file '{FULL_CODE_FILE_NAME}' has been created successfully.")
+            print(
+                f"Full code file '{FULL_CODE_FILE_NAME}' has been created successfully."
+            )
         except Exception as e:
             print(f"Error writing to file '{FULL_CODE_FILE_NAME}': {e}")
             sys.exit(1)

--- a/all_code.py
+++ b/all_code.py
@@ -236,13 +236,6 @@ def parse_arguments():
         help="Comma-separated list of programming extensions to use. Replaces the default set if provided.",
     )
     parser.add_argument(
-        "-e",
-        "--exclude-dirs",
-        type=str,
-        default="",
-        help="Comma-separated list of directories to exclude. Replaces the default set if provided.",
-    )
-    parser.add_argument(
         "-X",
         "--exclude-extensions",
         type=str,

--- a/all_code.py
+++ b/all_code.py
@@ -15,6 +15,8 @@ import os
 import argparse
 import sys
 import subprocess
+import pathlib
+import fnmatch
 
 # Define the master file name
 FULL_CODE_FILE_NAME = "full_code.txt"
@@ -48,7 +50,7 @@ PROGRAMMING_EXTENSIONS = {
     ".scala",
     ".pl",
     ".lua",
-    ".jl"
+    ".jl",
     # Web Development
     ".js",
     ".jsx",
@@ -91,7 +93,7 @@ PROGRAMMING_EXTENSIONS = {
 }
 
 # Define directories to exclude during file aggregation and directory tree generation
-EXCLUDE_DIRS = {
+DEFAULT_EXCLUDED_DIRS = {
     "venv",
     ".venv",
     "node_modules",
@@ -111,12 +113,13 @@ SCRIPT_NAME = os.path.basename(__file__)
 EXCLUDE_FILES = {SCRIPT_NAME, "package-lock.json", "package.json", "temp.py"}
 
 
-def generate_directory_tree(startpath):
-
-    #    Generates an ASCII directory tree.
-    #    - Excluded directories and their subdirectories are only listed by name without their internal files.
-    #    - The script itself is excluded from the tree.
-
+def generate_directory_tree(startpath, should_skip_dir):
+    """
+    Generates an ASCII directory tree.
+    - Excluded directories and their subdirectories are listed once and marked [EXCLUDED].
+    - The script itself is excluded from the tree.
+    Uses the provided should_skip_dir(dirpath) for exclusion logic.
+    """
     tree = ""
     for root, dirs, files in os.walk(startpath):
         # Determine the relative path from the startpath
@@ -138,8 +141,8 @@ def generate_directory_tree(startpath):
             else os.path.basename(startpath.rstrip(os.sep)) or startpath
         )
 
-        # Check if the current directory is excluded
-        if current_dir in EXCLUDE_DIRS:
+        # New: use should_skip_dir to decide whether to prune/display as EXCLUDED
+        if should_skip_dir(root):
             tree += f"{indent}{current_dir}/ [EXCLUDED]\n"
             dirs[:] = []  # Prevent os.walk from traversing further
             continue
@@ -170,11 +173,6 @@ def should_exclude(path):
     # Normalize path separators
     normalized_path = os.path.normpath(path)
     parts = normalized_path.split(os.sep)
-
-    # Check if any part of the path is in the EXCLUDE_DIRS
-    for part in parts[:-1]:  # Exclude the file name itself
-        if part in EXCLUDE_DIRS:
-            return True
 
     # Check if the file itself is in EXCLUDE_FILES
     if parts[-1] in EXCLUDE_FILES:
@@ -271,32 +269,11 @@ def _split_csv(s: str):
         return []
     parts = []
     for raw in s.split(","):
+        # remove all whitespace characters inside each token (incl. NBSP)
         p = "".join(ch for ch in raw if not ch.isspace())
         if p:
             parts.append(p)
     return parts
-
-
-DEFAULT_EXCLUDED_DIRS = {
-    "venv",
-    ".venv",
-    "node_modules",
-    "__pycache__",
-    ".git",
-    "dist",
-    "build",
-    "temp",
-    "old_files",
-    "flask_session",
-}
-
-
-# If '--replace-excluded-dirs' is not passed, default ignored are added to user choices.
-user_excluded = set(_split_csv(args.exclude_dirs))
-if args.replace_exclude_dirs:
-    effective_excluded = user_excluded
-else:
-    effective_excluded = set(DEFAULT_EXCLUDED_DIRS) | user_excluded
 
 
 # TODO: Works on MacOS and Windows 10+. Linux support can be added later
@@ -327,7 +304,7 @@ def main():
     args = parse_arguments()
 
     # Override the global options if command line arguments are provided.
-    global FULL_CODE_FILE_NAME, FILES_TO_INCLUDE, PROGRAMMING_EXTENSIONS, EXCLUDE_DIRS, EXCLUDE_EXTENSIONS
+    global FULL_CODE_FILE_NAME, FILES_TO_INCLUDE, PROGRAMMING_EXTENSIONS, EXCLUDE_EXTENSIONS
 
     if args.output_file:
         FULL_CODE_FILE_NAME = args.output_file
@@ -342,9 +319,6 @@ def main():
         PROGRAMMING_EXTENSIONS = {
             ext.strip() for ext in args.extensions.split(",") if ext.strip()
         }
-
-    if args.exclude_dirs:
-        EXCLUDE_DIRS = {d.strip() for d in args.exclude_dirs.split(",") if d.strip()}
 
     if args.exclude_extensions:
         EXCLUDE_EXTENSIONS = {
@@ -361,63 +335,112 @@ def main():
         )
         sys.exit(1)
 
-    if not os.path.isdir(startpath):
-        print(
-            f"Error: The specified directory '{startpath}' does not exist or is not a directory."
-        )
-        sys.exit(1)
+    # -------------------------
+    # Added build exclusion logic (additive -e, path-aware -e, per-file excludes)
+    # -------------------------
 
-    # Generate directory tree
-    directory_tree = generate_directory_tree(startpath)
+    # 1) Effective excluded directories (additive by default)
+    user_excluded = set(_split_csv(args.exclude_dirs))
+    effective_excluded = (
+        user_excluded
+        if args.replace_exclude_dirs
+        else (set(DEFAULT_EXCLUDED_DIRS) | user_excluded)
+    )
+
+    # 2) Build name & path-prefix lists for directories
+    exclude_dir_names = set()
+    exclude_dir_prefixes = []
+    for item in effective_excluded:
+        if not item:
+            continue
+        base = os.path.basename(item.rstrip(os.sep))
+        if base:
+            exclude_dir_names.add(base)
+        # treat path-like values as prefixes too
+        if os.sep in item or item.startswith("."):
+            prefix = os.path.abspath(os.path.expanduser(item))
+            try:
+                prefix = str(pathlib.Path(prefix).resolve())
+            except Exception:
+                pass
+            exclude_dir_prefixes.append(prefix)
+
+    # 3) File-level excludes (exact and glob)
+    exclude_file_globs = _split_csv(args.exclude_files)
+
+    # 4) Extension sets (NBSP-safe)
+    excluded_exts = set(_split_csv(args.exclude_extensions))
+    allowed_exts = set(
+        PROGRAMMING_EXTENSIONS
+    )  # PROGRAMMING_EXTENSIONS may be overridden above
+
+    # 5) Helpers used by tree and aggregation
+    def should_skip_dir(dirpath: str) -> bool:
+        base = os.path.basename(dirpath.rstrip(os.sep))
+        if base in exclude_dir_names:
+            return True
+        # Resolve to real path for prefix checks
+        try:
+            rp = str(pathlib.Path(dirpath).resolve())
+        except Exception:
+            rp = os.path.abspath(dirpath)
+        return any(rp.startswith(pref) for pref in exclude_dir_prefixes)
+
+    def should_skip_file(filepath: str) -> bool:
+        # extension-based exclusions
+        _, ext = os.path.splitext(filepath)
+        ext = ext.lower()
+        if ext and ext in excluded_exts:
+            return True
+        if allowed_exts and ext and ext not in allowed_exts:
+            return True
+        # file globs and exact matches (abs + project-relative)
+        if exclude_file_globs:
+            abs_path = os.path.abspath(filepath)
+            rel_path = os.path.relpath(filepath, startpath)
+            for pat in exclude_file_globs:
+                if (
+                    fnmatch.fnmatch(abs_path, pat)
+                    or fnmatch.fnmatch(rel_path, pat)
+                    or abs_path == pat
+                    or rel_path == pat
+                ):
+                    return True
+        # legacy file set
+        if os.path.basename(filepath) in EXCLUDE_FILES:
+            return True
+        return False
+
+    # Generate directory tree (using new exclusion logic)
+    directory_tree = generate_directory_tree(startpath, should_skip_dir)
 
     aggregated_content = "Directory Tree:\n" + directory_tree + "\n\n"
 
     # Traverse the directory again to process files
     for root, dirs, files in os.walk(startpath):
+        # NEW: prune directories in-place so os.walk does not descend into excluded dirs
+        dirs[:] = [d for d in dirs if not should_skip_dir(os.path.join(root, d))]
+
         # Determine the relative path from the startpath
         rel_path = os.path.relpath(root, startpath)
         if rel_path == ".":
             rel_path = ""
 
-        # Split the relative path into parts
-        path_parts = rel_path.split(os.sep) if rel_path else []
-
-        # Check if any parent directory is excluded
-        if any(part in EXCLUDE_DIRS for part in path_parts):
-            # Skip processing this directory and its subdirectories
-            dirs[:] = []  # Prevent os.walk from traversing further
-            continue
-
-        # Check if the current directory is excluded
-        current_dir = (
-            os.path.basename(root)
-            if rel_path
-            else os.path.basename(startpath.rstrip(os.sep)) or startpath
-        )
-        if current_dir in EXCLUDE_DIRS:
-            dirs[:] = []  # Prevent os.walk from traversing further
-            continue
-
         for file in files:
-
             file_path = os.path.join(root, file)
 
-            # Get file extension
-            _, ext = os.path.splitext(file)
-            ext = ext.lower()
-
-            # Skip files with excluded extensions
-            if ext in EXCLUDE_EXTENSIONS:
+            # Skip by extensions / globs / legacy excluded files
+            if should_skip_file(file_path):
                 continue
 
-            # Skip non-programming files
             if not is_programming_file(file):
                 continue
-            # Get relative path for exclusion and headers
-            rel_file_path = os.path.relpath(file_path, startpath)
 
-            if should_exclude(rel_file_path) or not should_include_file(file_path):
-                continue  # Skip excluded files or those not in FILES_TO_INCLUDE
+            if not should_include_file(file_path):
+                continue 
+
+            # Get relative path for headers
+            rel_file_path = os.path.relpath(file_path, startpath)
 
             header = f"\n\n# ======================\n# File: {rel_file_path}\n# ======================\n\n"
             aggregated_content += header

--- a/all_code.py
+++ b/all_code.py
@@ -284,6 +284,28 @@ def _split_csv(s: str):
     return parts
 
 
+DEFAULT_EXCLUDED_DIRS = {
+    "venv",
+    ".venv",
+    "node_modules",
+    "__pycache__",
+    ".git",
+    "dist",
+    "build",
+    "temp",
+    "old_files",
+    "flask_session",
+}
+
+
+# If '--replace-excluded-dirs' is not passed, default ignored are added to user choices.
+user_excluded = set(_split_csv(args.exclude_dirs))
+if args.replace_exclude_dirs:
+    effective_excluded = user_excluded
+else:
+    effective_excluded = set(DEFAULT_EXCLUDED_DIRS) | user_excluded
+
+
 # TODO: Works on MacOS and Windows 10+. Linux support can be added later
 def copy_to_clipboard(content):
     """Copy text to the system clipboard on macOS and Windows."""

--- a/test_all_code.py
+++ b/test_all_code.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import sys
 
 SCRIPT_PATH = os.path.join(os.path.dirname(os.path.realpath(__file__)), "all_code.py")
 
@@ -25,7 +26,7 @@ def run_script(args, cwd):
     """
     Run all_code.py with the provided command-line arguments in directory cwd.
     """
-    cmd = ["python", SCRIPT_PATH] + args
+    cmd = [sys.executable, SCRIPT_PATH] + args
     result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
     return result
 
@@ -35,7 +36,7 @@ def test_default_arguments():
     with tempfile.TemporaryDirectory() as tmp_dir:
         # Copy all_code.py to tmp directory  and run it without any args
         TMP_SCRIPT_PATH = shutil.copy(SCRIPT_PATH, tmp_dir)
-        cmd = ["python", TMP_SCRIPT_PATH]
+        cmd = [sys.executable, TMP_SCRIPT_PATH]
         subprocess.run(cmd, cwd=tmp_dir, capture_output=True, text=True)
 
         assert os.path.exists(os.path.join(tmp_dir, "full_code.txt")), "full_code.txt not created by default"
@@ -148,130 +149,136 @@ def test_exclude_dirs():
         assert "dummy.py" not in content, "File inside excluded directory should not be included"
         print("test_exclude_dirs passed.")
 
+def test_extensions_allowlist():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        py_file = os.path.join(tmpdir, "dummy.py")
+        with open(py_file, "w", encoding="utf-8") as f:
+            f.write("print('Python file')")
+        txt_file = os.path.join(tmpdir, "dummy.txt")
+        with open(txt_file, "w", encoding="utf-8") as f:
+            f.write("This is a text file.")
+        run_script(["-d", tmpdir, "-x", ".py"], cwd=tmpdir)
+        output_file = os.path.join(tmpdir, "full_code.txt")
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "dummy.py" in content, "dummy.py should be included with .py extension"
+        assert "This is a text file." not in content, "dummy.txt should be excluded when only .py is allowed"
+        print("test_extensions_allowlist() passed.")
+
+def test_exclude_dirs_additive():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        exclude_dir = os.path.join(tmpdir, "exclude_me")
+        os.mkdir(exclude_dir)
+        file_in_excluded = os.path.join(exclude_dir, "dummy.py")
+        with open(file_in_excluded, "w", encoding="utf-8") as f:
+            f.write("print('This file is in an excluded directory')")
+        run_script(["-d", tmpdir, "-e", "exclude_me"], cwd=tmpdir)
+        output_file = os.path.join(tmpdir, "full_code.txt")
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+        assert "exclude_me/ [EXCLUDED]" in content, "exclude_me directory should be marked as excluded"
+        assert "This file is in an excluded directory" not in content, "File inside excluded directory should not be included"
+        print("test_exclude_dirs_additive() passed.")
+
+
 def test_exclude_files_glob():
-    """
-    Ensure --exclude-files supports globs and exact paths, without blocking other files.
-    """
     with tempfile.TemporaryDirectory() as tmpdir:
         os.makedirs(os.path.join(tmpdir, "foo"), exist_ok=True)
 
-        # A JSON file we intend to exclude via glob
+        # a JSON file to exclude via glob
         cfg = os.path.join(tmpdir, "foo", "config.json")
         with open(cfg, "w", encoding="utf-8") as f:
             f.write('{"ok": true}')
 
-        # A keep file that should still be included
+        # a file that must remain included
         keep = os.path.join(tmpdir, "foo", "keep.py")
         with open(keep, "w", encoding="utf-8") as f:
             f.write("print('KEEP_ME')")
 
-        # Run with a glob that excludes the json file
+        # exclude via glob
         run_script(["-d", tmpdir, "--exclude-files", "foo/*.json"], cwd=tmpdir)
         output_file = os.path.join(tmpdir, "full_code.txt")
         with open(output_file, "r", encoding="utf-8") as f:
             content = f.read()
 
-        assert "config.json" not in content, "config.json should be excluded by glob"
-        assert "KEEP_ME" in content, "keep.py should still be included"
+        # tree should show the excluded file as [EXCLUDED]
+        assert "config.json [EXCLUDED]" in content, "Excluded file should be marked in the tree"
 
+        # aggregated content should NOT contain the file's contents
+        assert '{"ok": true}' not in content, "Excluded file contents must not be aggregated"
+
+        # keep.py stays in
+        assert "KEEP_ME" in content, "Non-excluded file should be included"
+        print("test_exclude_files_glob() passed.")
 
 def test_replace_exclude_dirs_behavior():
-    """
-    Ensure --replace-exclude-dirs replaces the defaults entirely.
-    - With replace: only the user-provided dirs are excluded (defaults like node_modules no longer excluded).
-    """
     with tempfile.TemporaryDirectory() as tmpdir:
-        # node_modules would normally be excluded by default
         node_modules_dir = os.path.join(tmpdir, "node_modules")
         os.makedirs(node_modules_dir, exist_ok=True)
         nm_file = os.path.join(node_modules_dir, "lib.js")
         with open(nm_file, "w", encoding="utf-8") as f:
             f.write("console.log('IN_NODE_MODULES');")
-
-        # custom_dir is the one we will exclude instead
         custom_dir = os.path.join(tmpdir, "custom_dir")
         os.makedirs(custom_dir, exist_ok=True)
         custom_file = os.path.join(custom_dir, "x.py")
         with open(custom_file, "w", encoding="utf-8") as f:
             f.write("print('IN_CUSTOM_DIR')")
-
-        # A normal file that should always be included
         root_py = os.path.join(tmpdir, "main.py")
         with open(root_py, "w", encoding="utf-8") as f:
             f.write("print('ROOT_OK')")
-
-        # Replace default excludes with ONLY 'custom_dir'
         run_script(["-d", tmpdir, "--replace-exclude-dirs", "-e", "custom_dir"], cwd=tmpdir)
         output_file = os.path.join(tmpdir, "full_code.txt")
         with open(output_file, "r", encoding="utf-8") as f:
             content = f.read()
-
-        # custom_dir should be excluded and marked; file inside should not appear
         assert "custom_dir/ [EXCLUDED]" in content, "custom_dir should be marked [EXCLUDED] when replaced"
         assert "IN_CUSTOM_DIR" not in content, "Files in custom_dir must be excluded in replace mode"
-
-        # node_modules should NOT be excluded anymore in replace mode → its file is included
         assert "IN_NODE_MODULES" in content, "node_modules should not be excluded in replace mode"
         assert "ROOT_OK" in content, "root file should be included"
-
+        print("test_replace_exclude_dirs_behavior() passed.")
 
 def test_extension_precedence_exclude_overrides_allowlist():
-    """
-    When both -x (allowlist) and -X (denylist) are provided,
-    the denylist should win for overlapping extensions.
-    """
     with tempfile.TemporaryDirectory() as tmpdir:
         js_file = os.path.join(tmpdir, "a.js")
         with open(js_file, "w", encoding="utf-8") as f:
             f.write("console.log('JS_INCLUDED?');")
-
         py_file = os.path.join(tmpdir, "b.py")
         with open(py_file, "w", encoding="utf-8") as f:
             f.write("print('PY_INCLUDED')")
-
-        # Allow .py and .js, but explicitly exclude .js
         run_script(["-d", tmpdir, "-x", ".py,.js", "-X", ".js"], cwd=tmpdir)
         output_file = os.path.join(tmpdir, "full_code.txt")
         with open(output_file, "r", encoding="utf-8") as f:
             content = f.read()
-
         assert "JS_INCLUDED?" not in content, ".js should be excluded by -X even if allowed by -x"
         assert "PY_INCLUDED" in content, ".py should remain included"
+        print("test_extension_precedence_exclude_overrides_allowlist() passed.")
 
 
 def test_tree_not_traversing_excluded():
-    """
-    Ensure directory tree prints '[EXCLUDED]' once for an excluded dir and does not traverse into it.
-    """
     with tempfile.TemporaryDirectory() as tmpdir:
         deep = os.path.join(tmpdir, "secret")
         os.makedirs(os.path.join(deep, "nested"), exist_ok=True)
         secret_file = os.path.join(deep, "nested", "hidden.py")
         with open(secret_file, "w", encoding="utf-8") as f:
             f.write("print('SHOULD_NOT_APPEAR')")
-
-        # Exclude the top-level 'secret' dir
         run_script(["-d", tmpdir, "-e", "secret"], cwd=tmpdir)
         output_file = os.path.join(tmpdir, "full_code.txt")
         with open(output_file, "r", encoding="utf-8") as f:
             content = f.read()
-
-        # Tree marks the top-level dir and stops
         assert "secret/ [EXCLUDED]" in content, "Top-level excluded dir should be marked once"
         assert "hidden.py" not in content, "Files inside excluded dir must not appear (no traversal)"
-
+        print("test_tree_not_traversing_excluded() passed.")
 
 if __name__ == "__main__":
-    # Keep running everything if executed directly
+    # Run everything if executed directly
     test_default_arguments()
     test_directory_argument()
     test_default_output()
     test_override_output_file()
     test_include_files()
-    # New tests
+    test_extensions_allowlist()
+    test_exclude_dirs_additive()
     test_exclude_files_glob()
     test_replace_exclude_dirs_behavior()
     test_extension_precedence_exclude_overrides_allowlist()
     test_tree_not_traversing_excluded()
-
     print("All tests passed!")

--- a/test_all_code.py
+++ b/test_all_code.py
@@ -148,13 +148,130 @@ def test_exclude_dirs():
         assert "dummy.py" not in content, "File inside excluded directory should not be included"
         print("test_exclude_dirs passed.")
 
+def test_exclude_files_glob():
+    """
+    Ensure --exclude-files supports globs and exact paths, without blocking other files.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "foo"), exist_ok=True)
+
+        # A JSON file we intend to exclude via glob
+        cfg = os.path.join(tmpdir, "foo", "config.json")
+        with open(cfg, "w", encoding="utf-8") as f:
+            f.write('{"ok": true}')
+
+        # A keep file that should still be included
+        keep = os.path.join(tmpdir, "foo", "keep.py")
+        with open(keep, "w", encoding="utf-8") as f:
+            f.write("print('KEEP_ME')")
+
+        # Run with a glob that excludes the json file
+        run_script(["-d", tmpdir, "--exclude-files", "foo/*.json"], cwd=tmpdir)
+        output_file = os.path.join(tmpdir, "full_code.txt")
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert "config.json" not in content, "config.json should be excluded by glob"
+        assert "KEEP_ME" in content, "keep.py should still be included"
+
+
+def test_replace_exclude_dirs_behavior():
+    """
+    Ensure --replace-exclude-dirs replaces the defaults entirely.
+    - With replace: only the user-provided dirs are excluded (defaults like node_modules no longer excluded).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # node_modules would normally be excluded by default
+        node_modules_dir = os.path.join(tmpdir, "node_modules")
+        os.makedirs(node_modules_dir, exist_ok=True)
+        nm_file = os.path.join(node_modules_dir, "lib.js")
+        with open(nm_file, "w", encoding="utf-8") as f:
+            f.write("console.log('IN_NODE_MODULES');")
+
+        # custom_dir is the one we will exclude instead
+        custom_dir = os.path.join(tmpdir, "custom_dir")
+        os.makedirs(custom_dir, exist_ok=True)
+        custom_file = os.path.join(custom_dir, "x.py")
+        with open(custom_file, "w", encoding="utf-8") as f:
+            f.write("print('IN_CUSTOM_DIR')")
+
+        # A normal file that should always be included
+        root_py = os.path.join(tmpdir, "main.py")
+        with open(root_py, "w", encoding="utf-8") as f:
+            f.write("print('ROOT_OK')")
+
+        # Replace default excludes with ONLY 'custom_dir'
+        run_script(["-d", tmpdir, "--replace-exclude-dirs", "-e", "custom_dir"], cwd=tmpdir)
+        output_file = os.path.join(tmpdir, "full_code.txt")
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # custom_dir should be excluded and marked; file inside should not appear
+        assert "custom_dir/ [EXCLUDED]" in content, "custom_dir should be marked [EXCLUDED] when replaced"
+        assert "IN_CUSTOM_DIR" not in content, "Files in custom_dir must be excluded in replace mode"
+
+        # node_modules should NOT be excluded anymore in replace mode → its file is included
+        assert "IN_NODE_MODULES" in content, "node_modules should not be excluded in replace mode"
+        assert "ROOT_OK" in content, "root file should be included"
+
+
+def test_extension_precedence_exclude_overrides_allowlist():
+    """
+    When both -x (allowlist) and -X (denylist) are provided,
+    the denylist should win for overlapping extensions.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        js_file = os.path.join(tmpdir, "a.js")
+        with open(js_file, "w", encoding="utf-8") as f:
+            f.write("console.log('JS_INCLUDED?');")
+
+        py_file = os.path.join(tmpdir, "b.py")
+        with open(py_file, "w", encoding="utf-8") as f:
+            f.write("print('PY_INCLUDED')")
+
+        # Allow .py and .js, but explicitly exclude .js
+        run_script(["-d", tmpdir, "-x", ".py,.js", "-X", ".js"], cwd=tmpdir)
+        output_file = os.path.join(tmpdir, "full_code.txt")
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert "JS_INCLUDED?" not in content, ".js should be excluded by -X even if allowed by -x"
+        assert "PY_INCLUDED" in content, ".py should remain included"
+
+
+def test_tree_not_traversing_excluded():
+    """
+    Ensure directory tree prints '[EXCLUDED]' once for an excluded dir and does not traverse into it.
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        deep = os.path.join(tmpdir, "secret")
+        os.makedirs(os.path.join(deep, "nested"), exist_ok=True)
+        secret_file = os.path.join(deep, "nested", "hidden.py")
+        with open(secret_file, "w", encoding="utf-8") as f:
+            f.write("print('SHOULD_NOT_APPEAR')")
+
+        # Exclude the top-level 'secret' dir
+        run_script(["-d", tmpdir, "-e", "secret"], cwd=tmpdir)
+        output_file = os.path.join(tmpdir, "full_code.txt")
+        with open(output_file, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Tree marks the top-level dir and stops
+        assert "secret/ [EXCLUDED]" in content, "Top-level excluded dir should be marked once"
+        assert "hidden.py" not in content, "Files inside excluded dir must not appear (no traversal)"
+
 
 if __name__ == "__main__":
+    # Keep running everything if executed directly
     test_default_arguments()
     test_directory_argument()
     test_default_output()
     test_override_output_file()
     test_include_files()
-    test_extensions()
-    test_exclude_dirs()
+    # New tests
+    test_exclude_files_glob()
+    test_replace_exclude_dirs_behavior()
+    test_extension_precedence_exclude_overrides_allowlist()
+    test_tree_not_traversing_excluded()
+
     print("All tests passed!")


### PR DESCRIPTION
This PR focuses on exclusion controls and added user control. It adds file-level excludes, makes -e additive by default, documents precedence of -X over -x, and documents changes in README for clarity. Default behavior for existing users is unchanged unless they opt into the new flags.

I wanted to make a slight adjustment on this excellent tool after I repeatedly could not generate an output. After much deliberation, I realized the tool did not accept a filepath as an argument for exclusions. 
 
In the pursuit of this fix, I found some other slight improvements that could be made upon this tool, trying not to deviate from my intention of focusing on file exclusions. I found users couldn’t exclude individual files via globs/paths, and the tree view didn’t explain why files were missing from aggregation. That made reviews and safety checks a bit less clear. 

If you prefer the previous default for -e (replace), I can flip the default and keep “additive” behind a new flag. I went with additive as the safer default because it prevents accidental re-inclusion of heavy or sensitive directories like node_modules or .venv. I ran into a few cases where the generation ran so long I could not even scroll it. 