### PR TITLE
Fix: Path normalization for file exclusions

### DIFF
--- a/all_code.py
+++ b/all_code.py
@@ -170,7 +170,7 @@ def make_is_tree_excluded_file(exclude_file_globs, excluded_exts, startpath):
     Tree-exclusion predicate. Used by the directory-tree printer only.
     Non-programming files are *not* tagged excluded just because they won't be aggregated.
     """
-    
+
     def _pred(filepath: str) -> bool:
         # extension-based denylist (user-provided -X)
         _, ext = os.path.splitext(filepath)
@@ -179,17 +179,8 @@ def make_is_tree_excluded_file(exclude_file_globs, excluded_exts, startpath):
             return True
 
         # --exclude-files globs or exact paths (abs or project-relative)
-        if exclude_file_globs:
-            abs_path = os.path.abspath(filepath)
-            rel_path = os.path.relpath(filepath, startpath)
-            for pat in exclude_file_globs:
-                if (
-                    fnmatch.fnmatch(abs_path, pat)
-                    or fnmatch.fnmatch(rel_path, pat)
-                    or abs_path == pat
-                    or rel_path == pat
-                ):
-                    return True
+        if exclude_file_globs and file_matches_exclude(filepath, exclude_file_globs, startpath):
+            return True
 
         return False
 
@@ -229,6 +220,28 @@ def should_include_file(file_path):
         return True  # Include all files if the list is empty
     rel_file_path = os.path.relpath(file_path)
     return rel_file_path in FILES_TO_INCLUDE
+
+
+def file_matches_exclude(filepath: str, exclude_file_globs, startpath: str) -> bool:
+    """
+    Match file against user-provided exclude patterns.
+    All comparisons are done on normalized absolute paths.
+    """
+    try:
+        abs_path = str(pathlib.Path(filepath).resolve())
+    except Exception:
+        abs_path = os.path.normpath(os.path.abspath(filepath))
+
+    for pat in exclude_file_globs:
+        # Exact match
+        if abs_path == pat:
+            return True
+
+        # Glob match
+        if fnmatch.fnmatch(abs_path, pat):
+            return True
+
+    return False
 
 
 def parse_arguments():
@@ -280,7 +293,7 @@ def parse_arguments():
         help="Comma-separated list of file extensions to exclude.",
     )
     """
-    Additional parser arguments:  
+    Additional parser arguments:
     """
     parser.add_argument(
         "-e",
@@ -364,7 +377,7 @@ def main():
         EXCLUDE_EXTENSIONS = {
             ext.strip() for ext in args.exclude_extensions.split(",") if ext.strip()
         }
-        
+
     # Users may include this script in output via --self.
     # By default we hide it to prevent the tool from including itself.
     if not args.self:
@@ -408,8 +421,21 @@ def main():
             exclude_dir_prefixes.append(prefix)
 
     # 3) File-level excludes (exact and glob)
-    exclude_file_globs = _split_csv(args.exclude_files)
-    
+    # Normalize --exclude-files patterns (relative → startpath, remove ./, fix slashes)
+    exclude_file_globs = []
+    for raw in _split_csv(args.exclude_files):
+        pat = os.path.expanduser(raw)
+
+        # If relative, anchor to startpath (NOT cwd)
+        if not os.path.isabs(pat):
+            pat = os.path.join(startpath, pat)
+
+        try:
+            pat = str(pathlib.Path(pat).resolve())
+        except Exception:
+            pat = os.path.normpath(pat)
+
+        exclude_file_globs.append(pat)
 
     # 4) Extension sets (NBSP-safe)
     excluded_exts = set(_split_csv(args.exclude_extensions))
@@ -444,7 +470,7 @@ def main():
         - matches --exclude-files (abs or project-relative)
         - legacy exclude set (EXCLUDE_FILES)
         """
-        
+
         # extension-based exclusions
         _, ext = os.path.splitext(filepath)
         ext = ext.lower()
@@ -453,17 +479,9 @@ def main():
         if allowed_exts and ext and ext not in allowed_exts:
             return True
         # file globs and exact matches (abs + project-relative)
-        if exclude_file_globs:
-            abs_path = os.path.abspath(filepath)
-            rel_path = os.path.relpath(filepath, startpath)
-            for pat in exclude_file_globs:
-                if (
-                    fnmatch.fnmatch(abs_path, pat)
-                    or fnmatch.fnmatch(rel_path, pat)
-                    or abs_path == pat
-                    or rel_path == pat
-                ):
-                    return True
+        if exclude_file_globs and file_matches_exclude(filepath, exclude_file_globs, startpath):
+            return True
+
         # legacy file set
         if os.path.basename(filepath) in EXCLUDE_FILES:
             return True
@@ -473,7 +491,7 @@ def main():
     #  1) print the tree (with explicit [EXCLUDED] tags for user-excludes)
     #  2) walk again to aggregate file contents (pruning excluded dirs)
     aggregated_content = "Directory Tree:\n" + directory_tree + "\n\n"
-    
+
     # Traverse the directory again to process files
     for root, dirs, files in os.walk(startpath):
         # NEW: prune directories in-place so os.walk does not descend into excluded dirs
@@ -495,7 +513,7 @@ def main():
                 continue
 
             if not should_include_file(file_path):
-                continue 
+                continue
 
             # Get relative path for headers
             rel_file_path = os.path.relpath(file_path, startpath)

--- a/test_all_code.py
+++ b/test_all_code.py
@@ -211,6 +211,109 @@ def test_exclude_files_glob():
         assert "KEEP_ME" in content, "Non-excluded file should be included"
         print("test_exclude_files_glob() passed.")
 
+def test_exclude_files_absolute_path():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "foo"), exist_ok=True)
+
+        cfg = os.path.join(tmpdir, "foo", "config.json")
+        with open(cfg, "w", encoding="utf-8") as f:
+            f.write('{"abs": true}')
+
+        run_script(
+            ["-d", tmpdir, "--exclude-files", cfg],
+            cwd=tmpdir,
+        )
+
+        with open(os.path.join(tmpdir, "full_code.txt"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert '{"abs": true}' not in content
+        print("test_exclude_files_absolute_path() passed.")
+
+def test_exclude_files_dot_slash():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "foo"), exist_ok=True)
+
+        cfg = os.path.join(tmpdir, "foo", "config.json")
+        with open(cfg, "w", encoding="utf-8") as f:
+            f.write('{"dot": true}')
+
+        run_script(
+            ["-d", tmpdir, "--exclude-files", "./foo/config.json"],
+            cwd=tmpdir,
+        )
+
+        with open(os.path.join(tmpdir, "full_code.txt"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert "config.json [EXCLUDED]" in content
+        assert '{"dot": true}' not in content
+        print("test_exclude_files_dot_slash() passed.")
+
+def test_exclude_files_cwd_differs_from_startpath():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        project = os.path.join(tmpdir, "project")
+        os.makedirs(os.path.join(project, "foo"), exist_ok=True)
+
+        cfg = os.path.join(project, "foo", "config.json")
+        with open(cfg, "w", encoding="utf-8") as f:
+            f.write('{"cwd": true}')
+
+        run_script(
+            ["-d", "project", "--exclude-files", "./foo/config.json"],
+            cwd=tmpdir,
+        )
+
+        with open(os.path.join(tmpdir, "full_code.txt"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert '{"cwd": true}' not in content
+        print("test_exclude_files_cwd_differs_from_startpath() passed.")
+
+def test_exclude_files_dot_slash_glob():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "foo"), exist_ok=True)
+
+        cfg = os.path.join(tmpdir, "foo", "config.json")
+        with open(cfg, "w", encoding="utf-8") as f:
+            f.write('{"glob": true}')
+
+        run_script(
+            ["-d", tmpdir, "--exclude-files", "./foo/*.json"],
+            cwd=tmpdir,
+        )
+
+        with open(os.path.join(tmpdir, "full_code.txt"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert '{"glob": true}' not in content
+        print("test_exclude_files_dot_slash_glob() passed.")
+
+def test_exclude_files_backslash_path():
+    if os.name != "nt":
+        print("Backslash paths are Windows-only")
+        return
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.makedirs(os.path.join(tmpdir, "foo"), exist_ok=True)
+
+        cfg = os.path.join(tmpdir, "foo", "config.json")
+        with open(cfg, "w", encoding="utf-8") as f:
+            f.write('{"win": true}')
+
+        win_style = os.path.join("foo", "config.json").replace("/", "\\")
+
+        run_script(
+            ["-d", tmpdir, "--exclude-files", win_style],
+            cwd=tmpdir,
+        )
+
+        with open(os.path.join(tmpdir, "full_code.txt"), "r", encoding="utf-8") as f:
+            content = f.read()
+
+        assert '{"win": true}' not in content
+        print("test_exclude_files_backslash_path() passed.")
+
 def test_replace_exclude_dirs_behavior():
     with tempfile.TemporaryDirectory() as tmpdir:
         node_modules_dir = os.path.join(tmpdir, "node_modules")
@@ -278,6 +381,11 @@ if __name__ == "__main__":
     test_extensions_allowlist()
     test_exclude_dirs_additive()
     test_exclude_files_glob()
+    test_exclude_files_absolute_path()
+    test_exclude_files_backslash_path()
+    test_exclude_files_cwd_differs_from_startpath()
+    test_exclude_files_dot_slash()
+    test_exclude_files_dot_slash_glob()
     test_replace_exclude_dirs_behavior()
     test_extension_precedence_exclude_overrides_allowlist()
     test_tree_not_traversing_excluded()


### PR DESCRIPTION
## Fix: Path normalization for file exclusions

### Issue:
Passing file paths with leading ./ or mismatched slashes to --exclude-files caused exclusions to fail because of strict string matching against normalized paths.

### Changes:
- Standardized all file exclusion logic to use absolute, resolved paths via pathlib.
- Anchored relative exclusion patterns to the target directory (-d) rather than the current working directory.
- Refactored exclusion matching into a helper function file_matches_exclude to ensure the Directory Tree and File Aggregator behave identically.

### Added Tests:
Added regression tests covering:
-   `./`-prefixed paths
-   absolute paths
-   glob patterns
-   differing `cwd` vs `-d`
-   Windows-style separators (NOTE: windows only)

Most new tests fail on `main` and all pass with this patch applied.

with the help from both gemini and chatgpt